### PR TITLE
chore(docs): add testing plan into docs folder

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,53 @@ First install the dependencies with `npm install` inside of server.
 
 Then run `npm run dev` and the project will be available at <http://localhost:9090>
 
+### Debugging the Server using Visual Studio Code
+1. Uncomment the `command: debug` line in the server part of the docker-compose.yml file at the root of the project. docker-compose.yml should look like this:
+
+```yml
+volumes:
+      - ./server:/code
+      - /code/node_modules
+    depends_on:
+      - mongo
+    command: debug 
+```
+
+2.  Rebuild the project using `make run-server` or `docker-compose up --build server`
+   
+3. Start by opening the the server folder in its on VS Code window.
+   
+4. In VS code on the debug tab click on "create launch.json" or click on the gear icon. Add the following to `"configurations:"` :
+```json
+    {
+      "type": "node",
+      "request": "attach",
+      "name": "Docker: Attach to Node server",
+      "port": 9229,
+      "remoteRoot": "/code/",
+      "localRoot": "${workspaceFolder}/",
+      "sourceMapPathOverrides": {
+        "/code/*": "${workspaceRoot}/*"
+      },
+      "skipFiles": [
+        "*node_internals*/**/*.js",
+        "node_modules",
+        "loader.js",
+        "async_hooks.js",
+        "bootstrap.js",
+        "**/async_hooks.js",
+        "**/webpack/bootstrap",
+        "**/internal/**/*",
+        "**/domain.js",
+        "**/events.js"
+      ],
+      "smartStep": true
+    }
+```
+
+3. Hit F5 or run the `Docker: Attach to Node server` configuration debugger, you should now be able to set breakpoints.
+
+
 ### MongoDB
 
 A local MongoDB container is used for development purposes. For convenience, mongo-express is also provided at <http://localhost:8081> to explore the database visually.
@@ -43,7 +90,7 @@ A local MongoDB container is used for development purposes. For convenience, mon
 | ------------------ | -------- |
 | Gordon Pham-Nguyen | 40018402 |
 | Naasir Jusab       | 40057665 |
-|                    |          |
+| Mackenzie Bellemore| 40062494 |
 |                    |          |
 |                    |          |
 |                    |          |

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -22,11 +22,13 @@ services:
       target: develop
     ports:
       - "9090:9090"
+      - "9229:9229"
     volumes:
       - ./server:/code
       - /code/node_modules
     depends_on:
       - mongo
+    # command: debug
 
   mongo:
     container_name: mongo

--- a/docs/testing_plan.md
+++ b/docs/testing_plan.md
@@ -1,0 +1,30 @@
+# SOEN-390 Testing Plan
+
+## Testing the Server
+
+### -- Goal --
+
+Our goal for testing our server side code was to achieve the 50% coverage on our controller classes. We also wanted to ensure that the tests were ran in the pipeline and the coverage requirements were met before being able to merge a pull request. Example tests can be found under `server/tests/unit`
+
+### -- Libraries Used --
+
+ - [Mocha](https://mochajs.org/) (test framework)
+ - [Sinon](https://sinonjs.org/) (Mocking library)
+ - [Chai](https://www.chaijs.com/) (Assertion Library)
+ - [Istanbul](https://istanbul.js.org/) (Coverage Library)
+
+#### Why we used these libraries:
+
+To test our controllers which are written in Typescript, we selected [Mocha](https://mochajs.org/) as our test framework. Mocha is open-source, extremely popular and offers extensive documentation and community support which made setting up our test environment easy. It also makes asynchronous testing simple which is a necessity for our application. We then selected [Sinon](https://sinonjs.org/) and [Chai](https://www.chaijs.com/) for all our mocking and assertion needs respectively. Again these are both open-source massively popular frameworks that are used in industry for stubs and assertions. Lastly we went with [Istanbul](https://istanbul.js.org/) which is a code coverage library that integrates with our testing framework, Mocha. It is highly configurable and can be used to output coverage reports or to block deployments which do not meet coverage requirements.
+
+Configuration file is found here `/server/.nycrc`
+
+### -- Unit Tests --
+
+Our main concern was to cover every controller with unit tests, meaning than any external calls leaving a controller file were stubbed/mocked. This ensures our classes are tested in complete isolation.
+
+### -- Pipeline --
+
+Lastly we implemented a CI pipeline using Github Actions, which protects our develop (main) branch by running the tests in the pipeline to ensure that coverage is met and that no unwanted bugs are introduced in these files. We targeted coverage on our controller classes and set the branch, line, function and statement coverage to 50% for a pull request to be merged.
+
+

--- a/server/app/App.ts
+++ b/server/app/App.ts
@@ -22,17 +22,13 @@ export class App {
     this.logger = container.get<Logger>(TYPES.logger);
   }
 
-  public init(): void {
+  public async init(): Promise<void> {
     try {
       const appBuilder = new InversifyExpressServer(container);
 
-      MongoConnection.initConnection(this.config)
-        .then(() => {
-          return MongoConnection.setAutoReconnect();
-        })
-        .catch((e) => {
-          throw e;
-        });
+      await MongoConnection.initConnection(this.config);
+      MongoConnection.setAutoReconnect();
+      this.logger.info('mongoDB connection initialized');
 
       appBuilder.setConfig((server: Application) => {
         // middlewares
@@ -78,6 +74,7 @@ export class App {
 
   public async close(): Promise<void> {
     try {
+      MongoConnection.disconnect();
       this.listener.close();
     } catch ({ message }) {
       this.logger.error(message);

--- a/server/app/index.ts
+++ b/server/app/index.ts
@@ -34,5 +34,9 @@ process.on('unhandledRejection', (reason: string, p: Promise<unknown>) => {
 process.on('SIGTERM', gracefulClose);
 process.on('SIGINT', gracefulClose);
 
-app.init();
-app.start().catch(uncaughtException);
+app
+  .init()
+  .then(() => {
+    return app.start();
+  })
+  .catch(uncaughtException);


### PR DESCRIPTION
[Link to view Debugger setup steps ](https://github.com/Mackbellemore/soen-390-team07/blob/f522e5be23ba93c76c2abc5f1e6d97fe499a7413/README.md#debugging-the-server-using-visual-studio-code)
[Link to view testing plan doc](https://github.com/Mackbellemore/soen-390-team07/blob/f522e5be23ba93c76c2abc5f1e6d97fe499a7413/docs/testing_plan.md)

- adds testing plan in the /docs folder
- added debugger setup steps
- await mongo connection before booting app