### PR TITLE
feat(client/server): Add logger and email notification in scheduling page

### DIFF
--- a/client/src/constants.js
+++ b/client/src/constants.js
@@ -142,7 +142,7 @@ export const appRoutes = [
   {
     name: 'Schedulings',
     protected: true,
-    allowedRoles: rolesAvailable,
+    allowedRoles: ['Admin', 'Manufacturing'],
     path: '/schedulings',
     icon: MdToday,
     component: lazy(() => import('components/views/SchedulingPage')),

--- a/server/app/controllers/MachineController.ts
+++ b/server/app/controllers/MachineController.ts
@@ -38,7 +38,7 @@ export class MachineController extends BaseController {
    * @param request
    * @returns       Machine JSON Format
    */
-  @httpPost('/')
+  @httpPost('/', TYPES.LoggerMiddleware)
   public async post(request: Request): Promise<results.JsonResult> {
     try {
       const machine: IMachine = await this.machineService.createMachine(request.body);
@@ -56,7 +56,7 @@ export class MachineController extends BaseController {
    * @param request
    * @returns       Machine JSON Format
    */
-  @httpDelete('/')
+  @httpDelete('/', TYPES.LoggerMiddleware)
   public async delete(request: Request): Promise<results.JsonResult> {
     try {
       const machine = await this.machineService.deleteMachine(request.body);


### PR DESCRIPTION
#

## Changes this PR introduces

- Send email when machine is in maintenance in schedule page 
- Sen email when create new schedule
- Add logger to machine controller
- Limit scheduling page to Admin and manufacturing roles

<!-- Write in bullet point form what this PR will add to the base branch when merged (high level point of view) -->

## How to test this PR

- Test locally 

<!-- Write about how a reviewer can manually test the features/changes of this PR  -->

## ClickUp reference

CU-rkar9p 

## Notes for reviewers

-

<!-- Anything you'd like the reviewers to be aware of -->

## Checklist

- [x] I renamed the title of my pull request to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] I have added tests to cover my changes (if applicable).
