### PR TITLE
feat(client): link production page with machine and scheduling pages

### DIFF
--- a/client/src/components/Production/ProductionModal.jsx
+++ b/client/src/components/Production/ProductionModal.jsx
@@ -89,7 +89,7 @@ const ProductionModal = ({ showButton = false }) => {
           <ModalBody pb={6}>
             <div style={styleBtn}>
               <Button onClick={form === 'Bike' ? onClickPart : onClickBike} colorScheme="teal">
-                {form === 'Bike' ? 'Part' : 'Bike'}
+                Change Production Type
               </Button>
             </div>
             <div style={formStyle}>

--- a/client/src/components/Production/ProductionModal.jsx
+++ b/client/src/components/Production/ProductionModal.jsx
@@ -49,6 +49,8 @@ const ProductionModal = ({ showButton = false }) => {
     partRefs,
     bikeRefs,
     styleBtn,
+    isSuccessMachine,
+    dataMachine,
     isEmptyField,
     onClickPart,
     onClickBike,
@@ -154,7 +156,14 @@ const ProductionModal = ({ showButton = false }) => {
             </div>
             <FormControl isRequired style={elementStyle}>
               <FormLabel>Assembly Machine</FormLabel>
-              <Input ref={assemblyMachineRef} onChange={handleChange} />
+              <Select ref={assemblyMachineRef}>
+                {isSuccessMachine &&
+                  dataMachine.data.map((machine) => (
+                    <Fragment key={machine}>
+                      <option value={machine.machineName}>{machine.machineName}</option>
+                    </Fragment>
+                  ))}
+              </Select>
             </FormControl>
             <FormControl style={elementStyle}>
               <FormLabel>Note</FormLabel>

--- a/client/src/hooks/useProductionModal.jsx
+++ b/client/src/hooks/useProductionModal.jsx
@@ -5,6 +5,7 @@ import { useQuery } from 'react-query';
 import { getParts, getPartMaterialList } from 'utils/api/parts';
 import { getMachines } from 'utils/api/machines';
 import useProductionTable from './useProductionTable.jsx';
+import { createScheduling } from 'utils/api/schedulings.js';
 
 const useProductionModal = () => {
   const { isSuccess: isSuccessPart, data: dataPart } = useQuery('parts', getParts);
@@ -173,6 +174,18 @@ const useProductionModal = () => {
           note: noteRef.current.value,
         });
       }
+      // update scheduling page
+      await createScheduling({
+        partType: nameRef.current.value,
+        quantity: quantityRef.current.value,
+        // 1-to-1 price of working this machine to the quantity
+        cost: quantityRef.current.value,
+        startTime: startDate,
+        endTime: endDate,
+        machineName: assemblyMachineRef.current.value,
+        frequency: 'Daily',
+      });
+
       toast({
         title: 'Production placed',
         description: 'Production successfully placed',

--- a/client/src/hooks/useProductionModal.jsx
+++ b/client/src/hooks/useProductionModal.jsx
@@ -196,6 +196,7 @@ const useProductionModal = () => {
       refetchProductions();
       refetchParts();
       refetchBikes();
+      onClose();
     } catch {
       toast({
         position: 'top',

--- a/client/src/hooks/useProductionModal.jsx
+++ b/client/src/hooks/useProductionModal.jsx
@@ -3,6 +3,7 @@ import { useState, useRef } from 'react';
 import { postProductions } from 'utils/api/productions';
 import { useQuery } from 'react-query';
 import { getParts, getPartMaterialList } from 'utils/api/parts';
+import { getMachines } from 'utils/api/machines';
 import useProductionTable from './useProductionTable.jsx';
 
 const useProductionModal = () => {
@@ -11,6 +12,7 @@ const useProductionModal = () => {
     'parts/MaterialList',
     getPartMaterialList
   );
+  const { isSuccess: isSuccessMachine, data: dataMachine } = useQuery('machine', getMachines);
 
   const { isOpen, onOpen, onClose } = useDisclosure();
   const toast = useToast();
@@ -196,6 +198,8 @@ const useProductionModal = () => {
   return {
     isSuccessPart,
     dataPart,
+    isSuccessMachine,
+    dataMachine,
     formStyle,
     elementStyle,
     isSuccessPartType,

--- a/server/app/entities/Scheduling.ts
+++ b/server/app/entities/Scheduling.ts
@@ -1,12 +1,11 @@
 import { BadRequestError } from '../errors';
 import Joi from 'joi';
-import { PartTypes } from './Part';
 import { IScheduling } from '../models/SchedulingModel';
 
 export default class SchedulingEntity {
   // Optional schema to validate Patch requests
   private static optionalSchema = Joi.object().keys({
-    partType: Joi.string().valid(...PartTypes),
+    partType: Joi.string(),
     quantity: Joi.number().integer().greater(-1),
     cost: Joi.number().integer().greater(-1),
     startTime: Joi.string(),


### PR DESCRIPTION
#

## Changes this PR introduces

- **assembly machine** input from production modal is now a select from machine available
- scheduling modal **partType** now takes any string which is the **name** of the production create

<!-- Write in bullet point form what this PR will add to the base branch when merged (high level point of view) -->

## How to test this PR

- create a part and a bike through the production page and assure that it's updated on the scheduling page

<!-- Write about how a reviewer can manually test the features/changes of this PR  -->

<!-- ## ClickUp reference -->

<!-- JUST the ClickUp ID if you did NOT use the generated branch name by ClickUp  -->

## Notes for reviewers

- don't be shy to tell me to redo anything, I will gladly change it

## Anything you'd like the reviewers to be aware of

- price of a machinery is now 1-to-1 with the quantity created
- machine work every day

## Checklist

- [x] I renamed the title of my pull request to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] I have added tests to cover my changes (if applicable).
