### PR TITLE
ci: use prod zeet branch for all netlify deploys

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -4,12 +4,7 @@
   command = "npm i && npm run export"
 [build.environment]
   NEXT_PUBLIC_MAPBOX= "pk.eyJ1IjoidXNlcmRldjAxIiwiYSI6ImNrbHZza3J1ejBxY3Yybm42c2NkOW1zNHAifQ.Wjw8BO1n9nz-2CJTEQ9DZA"
-[context.production.environment]
   NEXT_PUBLIC_API_URL = "https://mackbellemore-mackbellemore-soen-390-team07.zeet.app"
-[context.develop.environment]
-  NEXT_PUBLIC_API_URL = "https://mackbellemore-mackbellemore-soen-390-team07-develop.zeet.app"
-[context.deploy-preview.environment]
-  NEXT_PUBLIC_API_URL = "https://mackbellemore-mackbellemore-soen-390-team07-develop.zeet.app"
 [[redirects]]
   from = "/*"
   to = "/index.html"


### PR DESCRIPTION
#

## Changes this PR introduces

- We will switch the production branches of Zeet and Netlify to use `develop`
- This change is necessary to make sure Netlify uses the right backend

<!-- Write in bullet point form what this PR will add to the base branch when merged (high level point of view) -->

## How to test this PR

-

<!-- Write about how a reviewer can manually test the features/changes of this PR  -->

<!-- ## ClickUp reference -->

<!-- JUST the ClickUp ID if you did NOT use the generated branch name by ClickUp  -->

## Notes for reviewers

-

<!-- Anything you'd like the reviewers to be aware of -->

## Checklist

- [x] I renamed the title of my pull request to follow [Conventional Commits](https://www.conventionalcommits.org/en/v1.0.0/#summary).
- [x] I have added tests to cover my changes (if applicable).
